### PR TITLE
Map docs: Map update syntax is not for atom keys only

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -88,7 +88,7 @@ defmodule Map do
       %{1 => :one, 2 => :two, 3 => :three}
 
   Maps also support a specific update syntax to update the value stored under
-  *existing* atom keys:
+  *existing* keys:
 
       iex> map = %{one: 1, two: 2}
       iex> %{map | one: "one"}


### PR DESCRIPTION
Just a tiny change to remove the word `atom`, since this is also possible:

    %{foo | "bar" => "baz"}